### PR TITLE
update: обновлены доменные модели микросервиса Magazine

### DIFF
--- a/src/Magazine/Magazine.API/Program.cs
+++ b/src/Magazine/Magazine.API/Program.cs
@@ -1,53 +1,51 @@
+namespace Magazine.API;
 
-namespace Magazine.API
+public class Program
 {
-    public class Program
+    public static void Main(string[] args)
     {
-        public static void Main(string[] args)
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+        // Add services to the container.
+        builder.Services.AddAuthorization();
+
+        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+        builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddSwaggerGen();
+
+        WebApplication app = builder.Build();
+
+        // Configure the HTTP request pipeline.
+        if (app.Environment.IsDevelopment())
         {
-            var builder = WebApplication.CreateBuilder(args);
-
-            // Add services to the container.
-            builder.Services.AddAuthorization();
-
-            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-            builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
-
-            var app = builder.Build();
-
-            // Configure the HTTP request pipeline.
-            if (app.Environment.IsDevelopment())
-            {
-                app.UseSwagger();
-                app.UseSwaggerUI();
-            }
-
-            app.UseHttpsRedirection();
-
-            app.UseAuthorization();
-
-            var summaries = new[]
-            {
-                "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-            };
-
-            app.MapGet("/weatherforecast", (HttpContext httpContext) =>
-            {
-                var forecast = Enumerable.Range(1, 5).Select(index =>
-                    new WeatherForecast
-                    {
-                        Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                        TemperatureC = Random.Shared.Next(-20, 55),
-                        Summary = summaries[Random.Shared.Next(summaries.Length)]
-                    })
-                    .ToArray();
-                return forecast;
-            })
-            .WithName("GetWeatherForecast")
-            .WithOpenApi();
-
-            app.Run();
+            app.UseSwagger();
+            app.UseSwaggerUI();
         }
+
+        app.UseHttpsRedirection();
+
+        app.UseAuthorization();
+
+        string[] summaries =
+        [
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        ];
+
+        app.MapGet("/weatherforecast", (HttpContext httpContext) =>
+        {
+            WeatherForecast[] forecast = Enumerable.Range(1, 5).Select(index =>
+                new WeatherForecast
+                {
+                    Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                    TemperatureC = Random.Shared.Next(-20, 55),
+                    Summary = summaries[Random.Shared.Next(summaries.Length)]
+                })
+                .ToArray();
+            return forecast;
+        })
+        .WithName("GetWeatherForecast")
+        .WithOpenApi();
+
+        app.Run();
     }
 }

--- a/src/Magazine/Magazine.Domain/AggregatesModel/Magazine/Magazine.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/Magazine/Magazine.cs
@@ -3,14 +3,17 @@
 public class Magazine
 {
     public Guid Id { get; init; }
-    
+
     public string Name { get; init; } = null!;
-    
+
     public string? Description { get; set; }
-    
+
     public DateTime PublishDate { get; init; }
-    
+
     public PublishingHouse PublishingHouse { get; init; } = null!;
+
+    public override bool Equals(object? obj)
+        => Equals(obj as Magazine);
 
     public bool Equals(Magazine? magazine)
         => magazine != null &&
@@ -18,6 +21,13 @@ public class Magazine
             magazine.Name == Name &&
             magazine.PublishDate == PublishDate;
 
-    public override bool Equals(object? obj) 
-        => base.Equals(obj) ? true : Equals(obj as Magazine);
+    public override int GetHashCode()
+        => HashCode.Combine(Id, Name, Description, PublishDate, PublishingHouse);
+
+    public static bool operator ==(Magazine? a, Magazine? b)
+        => (a is null && b is null) ||
+           (a is not null && a.Equals(b));
+
+    public static bool operator !=(Magazine? a, Magazine? b)
+        => !(a == b);
 }

--- a/src/Magazine/Magazine.Domain/AggregatesModel/Magazine/Magazine.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/Magazine/Magazine.cs
@@ -1,9 +1,16 @@
 ﻿namespace Magazine.Domain.AggregatesModel;
-public class Magazine
+
+public class Magazine : IEquatable<Magazine>
 {
     public Guid Id { get; init; }
     public string Name { get; init; } = null!;
     public string? Description { get; set; }
     public DateTime PublishDate { get; init; }
     public PublishingHouse PublishingHouse { get; init; } = null!;
+
+    public bool Equals(Magazine? magazine)
+    => magazine != null &&
+        magazine.Id == Id &&
+        magazine.Name == Name &&
+        magazine.PublishDate == PublishDate;
 }

--- a/src/Magazine/Magazine.Domain/AggregatesModel/Magazine/Magazine.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/Magazine/Magazine.cs
@@ -1,0 +1,8 @@
+﻿namespace Magazine.Domain.AggregatesModel;
+public class Magazine
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Description { get; set; }
+    public DateTime PublishDate { get; set; }
+}

--- a/src/Magazine/Magazine.Domain/AggregatesModel/Magazine/Magazine.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/Magazine/Magazine.cs
@@ -1,8 +1,9 @@
 ﻿namespace Magazine.Domain.AggregatesModel;
 public class Magazine
 {
-    public Guid Id { get; set; }
-    public string Name { get; set; } = null!;
+    public Guid Id { get; init; }
+    public string Name { get; init; } = null!;
     public string? Description { get; set; }
-    public DateTime PublishDate { get; set; }
+    public DateTime PublishDate { get; init; }
+    public PublishingHouse PublishingHouse { get; init; } = null!;
 }

--- a/src/Magazine/Magazine.Domain/AggregatesModel/Magazine/Magazine.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/Magazine/Magazine.cs
@@ -1,16 +1,23 @@
 ﻿namespace Magazine.Domain.AggregatesModel;
 
-public class Magazine : IEquatable<Magazine>
+public class Magazine
 {
     public Guid Id { get; init; }
+    
     public string Name { get; init; } = null!;
+    
     public string? Description { get; set; }
+    
     public DateTime PublishDate { get; init; }
+    
     public PublishingHouse PublishingHouse { get; init; } = null!;
 
     public bool Equals(Magazine? magazine)
-    => magazine != null &&
-        magazine.Id == Id &&
-        magazine.Name == Name &&
-        magazine.PublishDate == PublishDate;
+        => magazine != null &&
+            magazine.Id == Id &&
+            magazine.Name == Name &&
+            magazine.PublishDate == PublishDate;
+
+    public override bool Equals(object? obj) 
+        => base.Equals(obj) ? true : Equals(obj as Magazine);
 }

--- a/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
@@ -2,6 +2,6 @@
 public class PublishingHouse
 {
     public Guid Id { get; init; }
-    public string Name { get; set; } = null!;
-    public DateTime FoundationYear { get; set; }
+    public string Name { get; init; } = null!;
+    public DateTime FoundationYear { get; init; }
 }

--- a/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
@@ -1,7 +1,27 @@
 ﻿namespace Magazine.Domain.AggregatesModel;
+
 public class PublishingHouse
 {
+    private readonly IList<Magazine> _magazines = [];
     public Guid Id { get; init; }
     public string Name { get; init; } = null!;
     public DateTime FoundationYear { get; init; }
+    public IReadOnlyCollection<Magazine> Magazines => _magazines.AsReadOnly();
+
+    public void AddMagazine(Magazine magazine)
+    {
+        if (magazine == null) return;
+        if (HasMagazine(magazine)) return;
+        _magazines.Add(magazine);
+    }
+    private bool HasMagazine(Magazine magazine)
+    {
+        if (_magazines.Count == 0) return false;
+        foreach (Magazine innerMagazine in _magazines)
+        {
+            if (innerMagazine.Equals(magazine)) return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
@@ -2,31 +2,74 @@
 
 public class PublishingHouse
 {
-    private readonly IList<Magazine> _magazines = [];
-    
-    public Guid Id { get; init; }
-    
-    public string Name { get; init; } = null!;
-    
-    public DateTime FoundationYear { get; init; }
-    
-    public IReadOnlyCollection<Magazine> Magazines => _magazines.AsReadOnly();
+    protected readonly IList<Magazine> MagazinesRegistry = [];
 
-    public void AddMagazine(Magazine magazine)
+    public Guid Id { get; init; }
+
+    public string Name { get; init; } = null!;
+
+    public DateTime FoundationYear { get; init; }
+
+    /// <summary>
+    /// Список журналов, которые публиковались в данном издании.
+    /// </summary>
+    public IReadOnlyCollection<Magazine> Magazines => MagazinesRegistry.AsReadOnly();
+
+    protected virtual bool HasMagazine(Magazine magazine)
     {
-        if (magazine == null) return;
-        if (HasMagazine(magazine)) return;
-        _magazines.Add(magazine);
-    }
-    
-    private bool HasMagazine(Magazine magazine)
-    {
-        if (_magazines.Count == 0) return false;
-        foreach (Magazine innerMagazine in _magazines)
+        if (MagazinesRegistry.Count == 0 || magazine == null) return false;
+
+        foreach (Magazine innerMagazine in MagazinesRegistry)
         {
             if (innerMagazine.Equals(magazine)) return true;
         }
 
         return false;
     }
+
+    public virtual void AddMagazine(Magazine magazine)
+    {
+        if (magazine == null || HasMagazine(magazine)) return;
+        MagazinesRegistry.Add(magazine);
+    }
+
+    public virtual void RemoveMagazine(Magazine magazine)
+    {
+        if (magazine == null || !HasMagazine(magazine)) return;
+        MagazinesRegistry.Remove(magazine);
+    }
+
+    public override bool Equals(object? obj)
+        => Equals(obj as PublishingHouse);
+
+    public bool Equals(PublishingHouse? other)
+    {
+        if (other == null/* || MagazinesRegistry.Count != other.Magazines.Count*/)
+            return false;
+
+        //int intersectCount = Enumerable
+        //    .Intersect(Magazines, other.Magazines)
+        //    .Count();
+
+        // Если есть хотя бы одно совпадение в изданных журналах, издательства считаются равными.
+        bool hasMatch = Magazines.Any(
+            inner => other.Magazines.Any(
+                outer => inner.Id == outer.Id));
+
+        return /*intersectCount == MagazinesRegistry.Count*/
+            hasMatch &&
+            Id == other.Id &&
+            Name == other.Name &&
+            FoundationYear == other.FoundationYear;
+    }
+
+    public override int GetHashCode()
+        => HashCode.Combine(MagazinesRegistry, Id, Name, FoundationYear);
+
+    public static bool operator ==(PublishingHouse? a, PublishingHouse? b)
+        => (a is null && b is null) ||
+           (a is not null && a.Equals(b));
+
+    public static bool operator !=(PublishingHouse? a, PublishingHouse? b)
+        => !(a == b);
 }

--- a/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
@@ -43,25 +43,10 @@ public class PublishingHouse
         => Equals(obj as PublishingHouse);
 
     public bool Equals(PublishingHouse? other)
-    {
-        if (other == null/* || MagazinesRegistry.Count != other.Magazines.Count*/)
-            return false;
-
-        //int intersectCount = Enumerable
-        //    .Intersect(Magazines, other.Magazines)
-        //    .Count();
-
-        // Если есть хотя бы одно совпадение в изданных журналах, издательства считаются равными.
-        bool hasMatch = Magazines.Any(
-            inner => other.Magazines.Any(
-                outer => inner.Id == outer.Id));
-
-        return /*intersectCount == MagazinesRegistry.Count*/
-            hasMatch &&
+        => other != null &&
             Id == other.Id &&
             Name == other.Name &&
             FoundationYear == other.FoundationYear;
-    }
 
     public override int GetHashCode()
         => HashCode.Combine(MagazinesRegistry, Id, Name, FoundationYear);

--- a/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
@@ -1,0 +1,7 @@
+﻿namespace Magazine.Domain.AggregatesModel;
+public class PublishingHouse
+{
+    public Guid Id { get; init; }
+    public string Name { get; set; } = null!;
+    public DateTime FoundationYear { get; set; }
+}

--- a/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
+++ b/src/Magazine/Magazine.Domain/AggregatesModel/PublishingHouse/PublishingHouse.cs
@@ -3,9 +3,13 @@
 public class PublishingHouse
 {
     private readonly IList<Magazine> _magazines = [];
+    
     public Guid Id { get; init; }
+    
     public string Name { get; init; } = null!;
+    
     public DateTime FoundationYear { get; init; }
+    
     public IReadOnlyCollection<Magazine> Magazines => _magazines.AsReadOnly();
 
     public void AddMagazine(Magazine magazine)
@@ -14,6 +18,7 @@ public class PublishingHouse
         if (HasMagazine(magazine)) return;
         _magazines.Add(magazine);
     }
+    
     private bool HasMagazine(Magazine magazine)
     {
         if (_magazines.Count == 0) return false;

--- a/src/Magazine/Magazine.Domain/Class1.cs
+++ b/src/Magazine/Magazine.Domain/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace Magazine.Domain
-{
-    public class Class1
-    {
-
-    }
-}

--- a/src/Magazine/Magazine.Domain/Magazine.Domain.csproj
+++ b/src/Magazine/Magazine.Domain/Magazine.Domain.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="AggregatesModel\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="Resources\Localizations\Localization.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Две правки:
+ Сущность `PublishingHouse` теперь теперь имеет дизайн, позволяющий осуществлять наиболее гибкое расширение не нарушая `OCP`.
+ При сравнении издательств, они будут считаться равными, если  между изданными/издаваемыми журналами будет хотя бы одно пересечение.

Вопросы:
+ Устраивает ли такой дизайн модели?
+ Какое правило для журналов в издательстве мы будем считать достаточным для заключения, что издательства равны?